### PR TITLE
Add quick demo page for kokoro-js

### DIFF
--- a/quick-demo/README.md
+++ b/quick-demo/README.md
@@ -1,0 +1,19 @@
+# Kokoro Quick Demo
+
+This is a minimal demo of the **kokoro-js** package. After installing the dependencies you can run `npm run dev` to start a local server.
+
+## Setup
+
+```bash
+# build the library first
+cd ../kokoro.js
+npm install
+npm run build
+
+# install demo dependencies
+cd ../quick-demo
+npm install
+npm run dev
+```
+
+Open the URL printed in the terminal (usually http://localhost:5173) to test text to speech. Edit the text box to change the spoken phrase and choose a voice from the dropdown.

--- a/quick-demo/index.html
+++ b/quick-demo/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Kokoro Quick Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    textarea { width: 100%; max-width: 600px; }
+  </style>
+</head>
+<body>
+  <h1>Kokoro Quick Demo</h1>
+  <textarea id="text" rows="4">Hello from Kokoro!</textarea>
+  <div>
+    <label for="voice">Voice:</label>
+    <select id="voice"></select>
+    <button id="speak">Speak</button>
+  </div>
+  <p id="status"></p>
+  <script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/quick-demo/main.js
+++ b/quick-demo/main.js
@@ -1,0 +1,38 @@
+import { KokoroTTS } from 'kokoro-js';
+
+const status = document.getElementById('status');
+const voiceSelect = document.getElementById('voice');
+const textInput = document.getElementById('text');
+const speakBtn = document.getElementById('speak');
+
+async function init() {
+  status.textContent = 'Loading model...';
+  const tts = await KokoroTTS.from_pretrained('onnx-community/Kokoro-82M-v1.0-ONNX', {
+    dtype: 'q8',
+    device: 'wasm'
+  });
+  status.textContent = 'Ready';
+
+  for (const [id, info] of Object.entries(tts.voices)) {
+    const opt = document.createElement('option');
+    opt.value = id;
+    opt.textContent = `${info.name} (${info.gender})`;
+    voiceSelect.appendChild(opt);
+  }
+
+  speakBtn.addEventListener('click', async () => {
+    speakBtn.disabled = true;
+    status.textContent = 'Generating...';
+    const audio = await tts.generate(textInput.value, { voice: voiceSelect.value });
+    const url = URL.createObjectURL(audio.toBlob());
+    const audioElem = new Audio(url);
+    audioElem.addEventListener('ended', () => {
+      speakBtn.disabled = false;
+      status.textContent = 'Ready';
+    });
+    status.textContent = 'Playing...';
+    audioElem.play();
+  });
+}
+
+init();

--- a/quick-demo/package.json
+++ b/quick-demo/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "kokoro-quick-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "kokoro-js": "file:../kokoro.js"
+  },
+  "devDependencies": {
+    "vite": "^6.0.1"
+  }
+}

--- a/quick-demo/vite.config.js
+++ b/quick-demo/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add `quick-demo` folder with a minimal Vite setup
- simple HTML page uses `kokoro-js` to speak text

## Testing
- `pytest -q` *(fails: pytest not found)*